### PR TITLE
Resource allocations now require a handle to the render backend

### DIFF
--- a/netcanv-renderer-opengl/src/rendering.rs
+++ b/netcanv-renderer-opengl/src/rendering.rs
@@ -795,6 +795,10 @@ impl RenderBackend for OpenGlBackend {
 
    type Framebuffer = Framebuffer;
 
+   fn create_image_from_rgba(&mut self, width: u32, height: u32, pixel_data: &[u8]) -> Self::Image {
+      Image::from_rgba(Rc::clone(&self.gl), width, height, pixel_data)
+   }
+
    fn create_framebuffer(&mut self, width: u32, height: u32) -> Self::Framebuffer {
       Framebuffer::new(
          Rc::clone(&self.gl),
@@ -840,10 +844,9 @@ impl RenderBackend for OpenGlBackend {
          Vertex::textured_colored(rect.top_left(), point(0.0, 0.0), color),
          Vertex::textured_colored(rect.bottom_right(), point(1.0, 1.0), color),
       );
-      let texture = image.upload(&self.gl);
       unsafe {
          self.gl.active_texture(glow::TEXTURE0);
-         self.gl.bind_texture(glow::TEXTURE_2D, Some(texture));
+         self.gl.bind_texture(glow::TEXTURE_2D, Some(image.texture.texture));
          let swizzle_mask = if image.color.is_some() {
             [glow::ONE, glow::ONE, glow::ONE, glow::ALPHA]
          } else {

--- a/netcanv-renderer-opengl/src/rendering.rs
+++ b/netcanv-renderer-opengl/src/rendering.rs
@@ -768,7 +768,7 @@ impl Renderer for OpenGlBackend {
    ) -> f32 {
       // Set up textures.
       unsafe {
-         let atlas = font.atlas(&self.freetype, &self.gl);
+         let atlas = font.atlas();
          self.gl.active_texture(glow::TEXTURE0);
          self.gl.bind_texture(glow::TEXTURE_2D, Some(atlas));
       }
@@ -797,6 +797,15 @@ impl RenderBackend for OpenGlBackend {
 
    fn create_image_from_rgba(&mut self, width: u32, height: u32, pixel_data: &[u8]) -> Self::Image {
       Image::from_rgba(Rc::clone(&self.gl), width, height, pixel_data)
+   }
+
+   fn create_font_from_memory(&mut self, data: &[u8], default_size: f32) -> Self::Font {
+      Font::new(
+         Rc::clone(&self.gl),
+         Rc::clone(&self.freetype),
+         data,
+         default_size,
+      )
    }
 
    fn create_framebuffer(&mut self, width: u32, height: u32) -> Self::Framebuffer {

--- a/netcanv-renderer/src/lib.rs
+++ b/netcanv-renderer/src/lib.rs
@@ -25,9 +25,6 @@ pub trait Font {
 
 /// An image.
 pub trait Image {
-   /// Creates an image from RGBA pixels.
-   fn from_rgba(width: u32, height: u32, pixel_data: &[u8]) -> Self;
-
    /// _Colorizes_ an image by replacing all of its color with a single, solid color.
    ///
    /// The alpha channel in the resulting image is multiplied with the given color's alpha channel.
@@ -102,6 +99,9 @@ pub enum BlendMode {
 pub trait RenderBackend: Renderer {
    type Image: Image;
    type Framebuffer: Framebuffer;
+
+   /// Creates a new image of the given size, from the given RGBA pixel data.
+   fn create_image_from_rgba(&mut self, width: u32, height: u32, pixel_data: &[u8]) -> Self::Image;
 
    /// Creates a new framebuffer of the given size.
    ///

--- a/netcanv-renderer/src/lib.rs
+++ b/netcanv-renderer/src/lib.rs
@@ -100,6 +100,7 @@ pub trait RenderBackend: Renderer {
    /// Creates a new image of the given size, from the given RGBA pixel data.
    fn create_image_from_rgba(&mut self, width: u32, height: u32, pixel_data: &[u8]) -> Self::Image;
 
+   /// Creates a new font from the given in-memory TTF/OTF file, with a set default size.
    fn create_font_from_memory(&mut self, data: &[u8], default_size: f32) -> Self::Font;
 
    /// Creates a new framebuffer of the given size.

--- a/netcanv-renderer/src/lib.rs
+++ b/netcanv-renderer/src/lib.rs
@@ -3,9 +3,6 @@ use paws::{vector, Color, Point, Rect, Renderer, Vector};
 
 /// A font.
 pub trait Font {
-   /// Creates a font from an in-memory file.
-   fn from_memory(memory: &[u8], default_size: f32) -> Self;
-
    /// Creates a new font of the same typeface, but with a different size.
    ///
    /// Backends should optimize this operation to be as cheap as possible.
@@ -103,12 +100,15 @@ pub trait RenderBackend: Renderer {
    /// Creates a new image of the given size, from the given RGBA pixel data.
    fn create_image_from_rgba(&mut self, width: u32, height: u32, pixel_data: &[u8]) -> Self::Image;
 
+   fn create_font_from_memory(&mut self, data: &[u8], default_size: f32) -> Self::Font;
+
    /// Creates a new framebuffer of the given size.
    ///
    /// The framebuffer should be cleared with transparent pixels.
    fn create_framebuffer(&mut self, width: u32, height: u32) -> Self::Framebuffer;
 
-   /// Draws to the provided framebuffer for the duration of `f`.
+   /// Sets the current framebuffer to the provided one, calls `f`, and sets the framebuffer
+   /// back to what it was before `draw_to` was called.
    fn draw_to(&mut self, framebuffer: &Self::Framebuffer, f: impl FnOnce(&mut Self));
 
    /// Clears the framebuffer with a solid color.

--- a/src/app/lobby.rs
+++ b/src/app/lobby.rs
@@ -12,6 +12,7 @@ use nysa::global as bus;
 
 use crate::app::{paint, AppState, StateArgs};
 use crate::assets::{Assets, ColorScheme, SwitchColorScheme};
+use crate::backend::Backend;
 use crate::common::{Error, Fatal};
 use crate::config::{self, UserConfig};
 use crate::net::peer::{self, Peer};
@@ -449,7 +450,7 @@ impl AppState for State {
       }
    }
 
-   fn next_state(self: Box<Self>) -> Box<dyn AppState> {
+   fn next_state(self: Box<Self>, renderer: &mut Backend) -> Box<dyn AppState> {
       let mut connected = false;
       if let Some(peer) = &self.peer {
          for message in &bus::retrieve_all::<peer::Connected>() {
@@ -469,6 +470,7 @@ impl AppState for State {
             this.config,
             this.peer.unwrap(),
             this.image_file,
+            renderer,
          ))
       } else {
          self

--- a/src/app/paint/mod.rs
+++ b/src/app/paint/mod.rs
@@ -99,7 +99,13 @@ impl State {
    pub const TIME_PER_UPDATE: Duration = Duration::from_millis(50);
 
    /// Creates a new paint state.
-   pub fn new(assets: Assets, config: UserConfig, peer: Peer, image_path: Option<PathBuf>) -> Self {
+   pub fn new(
+      assets: Assets,
+      config: UserConfig,
+      peer: Peer,
+      image_path: Option<PathBuf>,
+      renderer: &mut Backend,
+   ) -> Self {
       let mut this = Self {
          assets,
          config,
@@ -128,7 +134,7 @@ impl State {
          panning: false,
          viewport: Viewport::new(),
       };
-      this.register_tools();
+      this.register_tools(renderer);
 
       if this.peer.is_host() {
          log!(this.log, "Welcome to your room!");
@@ -149,11 +155,11 @@ impl State {
    }
 
    /// Registers all the tools.
-   fn register_tools(&mut self) {
-      self.register_tool(Box::new(SelectionTool::new()));
+   fn register_tools(&mut self, renderer: &mut Backend) {
+      self.register_tool(Box::new(SelectionTool::new(renderer)));
       // Set the default tool to the brush.
       self.current_tool = self.tools.borrow().len();
-      self.register_tool(Box::new(BrushTool::new()));
+      self.register_tool(Box::new(BrushTool::new(renderer)));
    }
 
    /// Executes the given callback with the currently selected tool.
@@ -758,7 +764,7 @@ impl AppState for State {
       self.process_bar(ui, input);
    }
 
-   fn next_state(self: Box<Self>) -> Box<dyn AppState> {
+   fn next_state(self: Box<Self>, _renderer: &mut Backend) -> Box<dyn AppState> {
       if self.fatal_error {
          Box::new(lobby::State::new(self.assets, self.config))
       } else {

--- a/src/app/paint/tools/brush.rs
+++ b/src/app/paint/tools/brush.rs
@@ -49,9 +49,9 @@ impl BrushTool {
    const MAX_THICKNESS: f32 = 64.0;
 
    /// Creates an instance of the brush tool.
-   pub fn new() -> Self {
+   pub fn new(renderer: &mut Backend) -> Self {
       Self {
-         icon: Assets::load_icon(include_bytes!("../../../assets/icons/brush.svg")),
+         icon: Assets::load_icon(renderer, include_bytes!("../../../assets/icons/brush.svg")),
          state: BrushState::Idle,
          thickness_slider: Slider::new(4.0, 1.0, Self::MAX_THICKNESS, SliderStep::Discrete(1.0)),
          color: COLOR_PALETTE[0],

--- a/src/app/paint/tools/selection.rs
+++ b/src/app/paint/tools/selection.rs
@@ -71,17 +71,25 @@ impl SelectionTool {
    /// The radius of handles for resizing the selection contents.
    const HANDLE_RADIUS: f32 = 4.0;
 
-   pub fn new() -> Self {
+   pub fn new(renderer: &mut Backend) -> Self {
       Self {
          icons: Icons {
-            tool: Assets::load_icon(include_bytes!("../../../assets/icons/selection.svg")),
-            cursor: Assets::load_icon(include_bytes!("../../../assets/icons/position.svg")),
-            position: Assets::load_icon(include_bytes!(
-               "../../../assets/icons/selection-position.svg"
-            )),
-            rectangle: Assets::load_icon(include_bytes!(
-               "../../../assets/icons/selection-rectangle.svg"
-            )),
+            tool: Assets::load_icon(
+               renderer,
+               include_bytes!("../../../assets/icons/selection.svg"),
+            ),
+            cursor: Assets::load_icon(
+               renderer,
+               include_bytes!("../../../assets/icons/position.svg"),
+            ),
+            position: Assets::load_icon(
+               renderer,
+               include_bytes!("../../../assets/icons/selection-position.svg"),
+            ),
+            rectangle: Assets::load_icon(
+               renderer,
+               include_bytes!("../../../assets/icons/selection-rectangle.svg"),
+            ),
          },
          mouse_position: point(0.0, 0.0),
          potential_action: Action::None,

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -1,5 +1,6 @@
 //! The trait all app states must implement.
 
+use crate::backend::Backend;
 use crate::ui::{Input, Ui};
 
 /// Arguments passed to app states.
@@ -20,5 +21,5 @@ pub trait AppState {
    ///
    /// If no state transitions should occur, this should simply return `self`. Otherwise, another
    /// app state may be constructed, boxed, and returned.
-   fn next_state(self: Box<Self>) -> Box<dyn AppState>;
+   fn next_state(self: Box<Self>, renderer: &mut Backend) -> Box<dyn AppState>;
 }

--- a/src/assets.rs
+++ b/src/assets.rs
@@ -22,7 +22,6 @@ const LIGHT_MODE_SVG: &[u8] = include_bytes!("assets/icons/light-mode.svg");
 pub struct ColorScheme {
    pub text: Color,
    pub panel: Color,
-   pub panel2: Color,
    pub separator: Color,
    pub error: Color,
 
@@ -91,8 +90,8 @@ impl Assets {
    /// Creates a new instance of Assets with the provided color scheme.
    pub fn new(renderer: &mut Backend, colors: ColorScheme) -> Self {
       Self {
-         sans: Font::from_memory(SANS_TTF, 14.0),
-         sans_bold: Font::from_memory(SANS_BOLD_TTF, 14.0),
+         sans: renderer.create_font_from_memory(SANS_TTF, 14.0),
+         sans_bold: renderer.create_font_from_memory(SANS_BOLD_TTF, 14.0),
          colors,
          icons: Icons {
             expand: ExpandIcons {
@@ -121,7 +120,6 @@ impl ColorScheme {
       Self {
          text: Color::argb(0xff000000),
          panel: Color::argb(0xffeeeeee),
-         panel2: Color::argb(0xffffffff),
          separator: Color::argb(0xff202020),
          error: Color::argb(0xff7f0000),
 
@@ -185,7 +183,6 @@ impl ColorScheme {
       Self {
          text: Color::argb(0xffb7b7b7),
          panel: Color::argb(0xff1f1f1f),
-         panel2: Color::argb(0xffffffff),
          separator: Color::argb(0xff202020),
          error: Color::argb(0xfffc9292),
 

--- a/src/assets.rs
+++ b/src/assets.rs
@@ -1,7 +1,7 @@
 //! Handling of assets such as icons, fonts, etc.
 
 use netcanv_renderer::paws::Color;
-use netcanv_renderer::{Font as FontTrait, Image as ImageTrait, RenderBackend};
+use netcanv_renderer::{Font as FontTrait, RenderBackend};
 
 use crate::backend::{Backend, Font, Image};
 use crate::ui::{ButtonColors, ExpandColors, ExpandIcons, TextFieldColors};

--- a/src/assets.rs
+++ b/src/assets.rs
@@ -1,9 +1,9 @@
 //! Handling of assets such as icons, fonts, etc.
 
 use netcanv_renderer::paws::Color;
-use netcanv_renderer::{Font as FontTrait, Image as ImageTrait};
+use netcanv_renderer::{Font as FontTrait, Image as ImageTrait, RenderBackend};
 
-use crate::backend::{Font, Image};
+use crate::backend::{Backend, Font, Image};
 use crate::ui::{ButtonColors, ExpandColors, ExpandIcons, TextFieldColors};
 
 const SANS_TTF: &[u8] = include_bytes!("assets/fonts/Barlow-Medium.ttf");
@@ -73,7 +73,7 @@ pub struct Assets {
 
 impl Assets {
    /// Loads an icon from an SVG file.
-   pub fn load_icon(data: &[u8]) -> Image {
+   pub fn load_icon(renderer: &mut Backend, data: &[u8]) -> Image {
       use usvg::{FitTo, NodeKind, Tree};
 
       let tree =
@@ -85,30 +85,30 @@ impl Assets {
       let mut pixmap = tiny_skia::Pixmap::new(size.width() as u32, size.height() as u32).unwrap();
       resvg::render(&tree, FitTo::Original, pixmap.as_mut());
 
-      Image::from_rgba(size.width() as u32, size.height() as u32, pixmap.data())
+      renderer.create_image_from_rgba(size.width() as u32, size.height() as u32, pixmap.data())
    }
 
    /// Creates a new instance of Assets with the provided color scheme.
-   pub fn new(colors: ColorScheme) -> Self {
+   pub fn new(renderer: &mut Backend, colors: ColorScheme) -> Self {
       Self {
          sans: Font::from_memory(SANS_TTF, 14.0),
          sans_bold: Font::from_memory(SANS_BOLD_TTF, 14.0),
          colors,
          icons: Icons {
             expand: ExpandIcons {
-               expand: Self::load_icon(CHEVRON_RIGHT_SVG),
-               shrink: Self::load_icon(CHEVRON_DOWN_SVG),
+               expand: Self::load_icon(renderer, CHEVRON_RIGHT_SVG),
+               shrink: Self::load_icon(renderer, CHEVRON_DOWN_SVG),
             },
             status: StatusIcons {
-               info: Self::load_icon(INFO_SVG),
-               error: Self::load_icon(ERROR_SVG),
+               info: Self::load_icon(renderer, INFO_SVG),
+               error: Self::load_icon(renderer, ERROR_SVG),
             },
             file: FileIcons {
-               save: Self::load_icon(SAVE_SVG),
+               save: Self::load_icon(renderer, SAVE_SVG),
             },
             color_switcher: ColorSwitcherIcons {
-               dark: Self::load_icon(DARK_MODE_SVG),
-               light: Self::load_icon(LIGHT_MODE_SVG),
+               dark: Self::load_icon(renderer, DARK_MODE_SVG),
+               light: Self::load_icon(renderer, LIGHT_MODE_SVG),
             },
          },
       }

--- a/src/main.rs
+++ b/src/main.rs
@@ -66,7 +66,7 @@ fn inner_main() -> anyhow::Result<()> {
    let event_loop = EventLoop::new();
    let window_builder = {
       let b = WindowBuilder::new()
-         .with_inner_size(LogicalSize::new(1024, 600))
+         .with_inner_size(LogicalSize::<u16>::new(1024, 600))
          .with_title("NetCanv")
          .with_resizable(true);
       // On Linux, winit doesn't seem to set the app ID properly so Wayland compositors can't tell
@@ -98,7 +98,7 @@ fn inner_main() -> anyhow::Result<()> {
    let mut ui = Ui::new(renderer);
 
    // Load all the assets, and start the first app state.
-   let assets = Assets::new(color_scheme);
+   let assets = Assets::new(ui.render(), color_scheme);
    let mut app: Option<Box<dyn AppState>> = Some(Box::new(lobby::State::new(assets, config)) as _);
    let mut input = Input::new();
 
@@ -127,7 +127,7 @@ fn inner_main() -> anyhow::Result<()> {
                   input: &mut input,
                });
                // See? Told ya.
-               app = Some(app.take().unwrap().next_state());
+               app = Some(app.take().unwrap().next_state(ui.render()));
             }) {
                Err(error) => eprintln!("render error: {}", error),
                _ => (),


### PR DESCRIPTION
`Font::from_memory` and `Image::from_rgba` have been replaced with `RenderBackend::create_font_from_memory` and `RenderBackend::create_image_from_rgba`, respectively.