### PR TITLE
Rename matchmaker to relay

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,8 +23,8 @@ jobs:
 
     - name: Compile application
       run: cargo build --release
-    - name: Compile matchmaker
-      working-directory: netcanv-matchmaker
+    - name: Compile relay
+      working-directory: netcanv-relay
       run: cargo build --release
 
     - name: Build AppImages
@@ -44,8 +44,8 @@ jobs:
 
     - name: Compile application
       run: cargo build --release
-    - name: Compile matchmaker
-      working-directory: netcanv-matchmaker
+    - name: Compile relay
+      working-directory: netcanv-relay
       run: cargo build --release
 
     - name: Apply icons to executables
@@ -57,7 +57,7 @@ jobs:
         name: netcanv-nightly-windows
         path: |
           target/release/netcanv.exe
-          target/release/netcanv-matchmaker.exe
+          target/release/netcanv-relay.exe
 
   release:
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1130,7 +1130,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "netcanv-matchmaker"
+name = "netcanv-protocol"
+version = "0.5.0"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "netcanv-relay"
 version = "2.0.0"
 dependencies = [
  "anyhow",
@@ -1141,13 +1148,6 @@ dependencies = [
  "serde",
  "structopt",
  "tokio",
-]
-
-[[package]]
-name = "netcanv-protocol"
-version = "0.5.0"
-dependencies = [
- "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 members = [
    "netcanv-renderer",
    "netcanv-renderer-opengl",
-   "netcanv-matchmaker",
+   "netcanv-relay",
    "netcanv-protocol",
 ]
 

--- a/README.md
+++ b/README.md
@@ -48,15 +48,14 @@ may be added after 1.0 is released.
 There used to be a Skia backend, but it was removed because it was an unsupported, unnecessary
 maintenance burden. The last tag to feature this backend is [0.5.0](https://github.com/liquidev/netcanv/tree/0.5.0).
 
-### Matchmaker
+### Relay
 
-NetCanv assumes that you have your own matchmaker up: currently the default value
-in the matchmaker textbox is `localhost`, for easy testing.
+NetCanv assumes that you have your own relay server up: currently the default value
+in the relay textbox is `localhost`, for easy testing.
 
-To run the matchmaker, simply do:
+To run the relay server, simply do:
 ```sh
-$ cd netcanv-matchmaker
-$ cargo run --release
+$ cargo run -p netcanv-relay
 ```
 
 This will allow you to host and join new rooms locally.

--- a/build/appimages.sh
+++ b/build/appimages.sh
@@ -17,12 +17,12 @@ chmod +x linuxdeploy-x86_64.AppImage
   --output appimage
 
 ./linuxdeploy-x86_64.AppImage \
-  --appdir NetCanv-Matchmaker-AppDir \
-  --executable target/release/netcanv-matchmaker \
+  --appdir NetCanv-Relay-AppDir \
+  --executable target/release/netcanv-relay \
   --icon-file resources/netcanv.png \
-  --desktop-file resources/netcanv-matchmaker.desktop \
+  --desktop-file resources/netcanv-relay.desktop \
   --output appimage
 
 mkdir appimages
-mv NetCanv-*.AppImage NetCanv_Matchmaker-*.AppImage appimages
+mv NetCanv-*.AppImage NetCanv_Relay-*.AppImage appimages
 rm -r NetCanv*-AppDir

--- a/build/windows-icons.ps1
+++ b/build/windows-icons.ps1
@@ -1,6 +1,6 @@
 # Modify these if the executable location ever changes.
 $app_executable = "target/release/netcanv.exe"
-$matchmaker_executable = "target/release/netcanv-matchmaker.exe"
+$relay_executable = "target/release/netcanv-relay.exe"
 
 # Helper for retrieving the version of the crate. This is used to set the product version.
 function Get-CrateVersion {
@@ -10,11 +10,11 @@ function Get-CrateVersion {
 
 Write-Output "Obtaining crate versions"
 $app_version = Get-CrateVersion
-Set-Location netcanv-matchmaker
-$matchmaker_version = Get-CrateVersion
+Set-Location netcanv-relay
+$relay_version = Get-CrateVersion
 Set-Location ..
 Write-Output "netcanv: $app_version"
-Write-Output "netcanv-matchmaker: $matchmaker_version"
+Write-Output "netcanv-relay: $relay_version"
 
 # Generate the copyright info according to the current year.
 $company_name = "liquidev"
@@ -54,7 +54,7 @@ Set-Resources -Executable $app_executable `
    -Version "$app_version" `
    -Description "Online collaborative paint canvas"
 
-Set-Resources -Executable $matchmaker_executable `
-   -Name "NetCanv Matchmaker" `
-   -Version "$matchmaker_version" `
-   -Description "Matchmaker and packet relay server for NetCanv"
+Set-Resources -Executable $relay_executable `
+   -Name "NetCanv Relay" `
+   -Version "$relay_version" `
+   -Description "Relay server for NetCanv"

--- a/netcanv-protocol/src/lib.rs
+++ b/netcanv-protocol/src/lib.rs
@@ -1,2 +1,2 @@
 pub mod client;
-pub mod matchmaker;
+pub mod relay;

--- a/netcanv-protocol/src/relay.rs
+++ b/netcanv-protocol/src/relay.rs
@@ -1,10 +1,10 @@
-// matchmaker packets
+//! Relay packaets.
 
 use std::fmt::{self, Display, Formatter};
 
 use serde::{Deserialize, Serialize};
 
-/// The default matchmaker port.
+/// The default relay port.
 pub const DEFAULT_PORT: u16 = 62137;
 
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
@@ -12,17 +12,17 @@ pub enum Packet {
    // ---
    // Initial hosting procedure
    // ---
-   /// Request from the host to the matchmaker for a free room ID.
+   /// Request from the host to the relay for a free room ID.
    Host,
-   /// Response from the matchmaker to the host containing the room ID, and the peer ID inside the
+   /// Response from the relay to the host containing the room ID, and the peer ID inside the
    /// room.
    RoomCreated(RoomId, PeerId),
    /// Request sent from a client, to join a room with the given ID.
    Join(RoomId),
-   /// Response from the matchmaker to the client containing the client's peer ID and the host's
+   /// Response from the relay to the client containing the client's peer ID and the host's
    /// peer ID.
    Joined { peer_id: PeerId, host_id: PeerId },
-   /// Message from the matchmaker that the host has disconnected, and that the host role now
+   /// Message from the relay that the host has disconnected, and that the host role now
    /// belongs to the peer with the given ID.
    HostTransfer(PeerId),
 

--- a/netcanv-relay/Cargo.toml
+++ b/netcanv-relay/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "netcanv-matchmaker"
+name = "netcanv-relay"
 version = "2.0.0"
 edition = "2021"
 

--- a/resources/netcanv-matchmaker.desktop
+++ b/resources/netcanv-matchmaker.desktop
@@ -1,9 +1,9 @@
 [Desktop Entry]
 Type=Application
 Encoding=UTF-8
-Name=NetCanv Matchmaker
-Comment=Server for Multiplayer Paint
-Exec=netcanv-matchmaker
+Name=NetCanv Relay
+Comment=Relay server for NetCanv
+Exec=netcanv-relay
 Icon=netcanv
 Categories=Graphics;Network
 Terminal=true

--- a/src/app/paint/mod.rs
+++ b/src/app/paint/mod.rs
@@ -9,7 +9,7 @@ use std::path::PathBuf;
 use std::rc::Rc;
 use std::time::{Duration, Instant};
 
-use netcanv_protocol::matchmaker::PeerId;
+use netcanv_protocol::relay::PeerId;
 use netcanv_renderer::paws::{
    point, vector, AlignH, AlignV, Alignment, Color, Layout, Rect, Renderer, Vector,
 };

--- a/src/app/paint/tools/brush.rs
+++ b/src/app/paint/tools/brush.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use std::time::Instant;
 
 use crate::backend::winit::event::MouseButton;
-use netcanv_protocol::matchmaker::PeerId;
+use netcanv_protocol::relay::PeerId;
 use netcanv_renderer::paws::{
    point, vector, AlignH, AlignV, Color, Layout, LineCap, Point, Rect, Renderer,
 };

--- a/src/app/paint/tools/mod.rs
+++ b/src/app/paint/tools/mod.rs
@@ -15,7 +15,7 @@ mod brush;
 mod selection;
 
 pub use brush::*;
-use netcanv_protocol::matchmaker::PeerId;
+use netcanv_protocol::relay::PeerId;
 pub use selection::*;
 use serde::Serialize;
 

--- a/src/app/paint/tools/selection.rs
+++ b/src/app/paint/tools/selection.rs
@@ -6,7 +6,7 @@ use crate::backend::winit::event::{MouseButton, VirtualKeyCode};
 use image::io::Reader;
 use image::png::PngEncoder;
 use image::{ColorType, ImageFormat, RgbaImage};
-use netcanv_protocol::matchmaker::PeerId;
+use netcanv_protocol::relay::PeerId;
 use netcanv_renderer::paws::{point, vector, AlignH, AlignV, Color, Point, Rect, Renderer, Vector};
 use netcanv_renderer::{
    BlendMode, Font as FontTrait, Framebuffer as FramebufferTrait, RenderBackend,

--- a/src/config.rs
+++ b/src/config.rs
@@ -14,7 +14,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Deserialize, Serialize)]
 pub struct LobbyConfig {
    pub nickname: String,
-   pub matchmaker: String,
+   pub relay: String,
 }
 
 /// The color scheme variant.
@@ -115,7 +115,7 @@ impl Default for UserConfig {
       Self {
          lobby: LobbyConfig {
             nickname: "Anon".to_owned(),
-            matchmaker: "localhost".to_owned(),
+            relay: "localhost".to_owned(),
          },
          ui: UiConfig {
             color_scheme: ColorScheme::Light,

--- a/src/config.rs
+++ b/src/config.rs
@@ -14,6 +14,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Deserialize, Serialize)]
 pub struct LobbyConfig {
    pub nickname: String,
+   #[serde(alias = "matchmaker")]
    pub relay: String,
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@
 //  - assets.rs - asset loading and color schemes.
 //  - assets/ - does not contain any code, but rather actual assets, such as fonts and icons.
 //  - app/ - contains app states (the lobby and paint UI).
-//  - net/ - contains networking-related code (communicating with the matchmaker and other clients).
+//  - net/ - contains networking-related code (communicating with the relay and other clients).
 //  - ui/ - contains NetCanv's bespoke UI framework, as well as all the widgets.
 //
 // This list may become out of date with time, as the app gets refactored, so feel free to explore,


### PR DESCRIPTION
The name "relay" is more fitting. The name "matchmaker" implies that the server finds random, free rooms, like in multiplayer video games, while it's really not much more than a packet relay.