### PR TITLE
Socket system rewritten to use tokio

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1060,6 +1060,7 @@ dependencies = [
  "strum",
  "tempfile",
  "tiny-skia",
+ "tokio",
  "toml",
  "url",
  "usvg",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ tiny-skia = { version = "0.5.0", default-features = false, features = ["std", "s
 # Networking
 serde = { version = "1.0.123", features = ["derive"] }
 bincode = "1.3.2"
+tokio = { version = "1.14.0", features = ["full"] }
 
 # Multithreading
 nysa = "0.2.2"

--- a/src/app/paint/mod.rs
+++ b/src/app/paint/mod.rs
@@ -6,6 +6,7 @@ mod tools;
 
 use std::collections::HashMap;
 use std::path::PathBuf;
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use netcanv_protocol::relay::PeerId;
@@ -24,6 +25,7 @@ use crate::backend::Backend;
 use crate::clipboard;
 use crate::common::*;
 use crate::net::peer::{self, Peer};
+use crate::net::socket::SocketSystem;
 use crate::net::timer::Timer;
 use crate::paint_canvas::*;
 use crate::ui::view::layout::DirectionV;
@@ -70,6 +72,7 @@ pub struct GlobalControls {
 /// The paint app state.
 pub struct State {
    assets: Assets,
+   _socket_system: Arc<SocketSystem>,
 
    paint_canvas: PaintCanvas,
 
@@ -130,6 +133,7 @@ impl State {
    /// Creates a new paint state.
    pub fn new(
       assets: Assets,
+      socket_system: Arc<SocketSystem>,
       peer: Peer,
       image_path: Option<PathBuf>,
       renderer: &mut Backend,
@@ -137,6 +141,7 @@ impl State {
       let mut wm = WindowManager::new();
       let mut this = Self {
          assets,
+         _socket_system: socket_system,
 
          paint_canvas: PaintCanvas::new(),
 

--- a/src/net/socket.rs
+++ b/src/net/socket.rs
@@ -1,263 +1,199 @@
 //! An abstraction for sockets, communicating over the global bus.
 
-use std::fmt::Debug;
-use std::io::{BufWriter, Write};
-use std::marker::PhantomData;
-use std::net::{Shutdown, SocketAddr, TcpStream, ToSocketAddrs};
-use std::sync::{Arc, Mutex};
-use std::thread::{self, JoinHandle};
+use std::net::SocketAddr;
+use std::sync::Arc;
 
-use nysa::global as bus;
-use serde::de::DeserializeOwned;
-use serde::Serialize;
+use anyhow::Context;
+use netcanv_protocol::relay;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{lookup_host, tcp, TcpStream};
+use tokio::sync::{mpsc, oneshot, Mutex};
+use tokio::task::JoinHandle;
 
-use crate::token::Token;
-
-/// A token for connecting a socket asynchronously.
-///
-/// Once a socket connects successfully, [`Connected`] is pushed onto the bus, containing this
-/// token and the socket handle.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct ConnectionToken(usize);
-
-/// A successful connection message.
-pub struct Connected<T>
-where
-   T: 'static + Send + DeserializeOwned + Serialize + Debug,
-{
-   pub token: ConnectionToken,
-   pub socket: Socket<T>,
+/// Runtime for managing active connections.
+pub struct SocketSystem {
+   runtime: tokio::runtime::Runtime,
+   quitters: Mutex<Vec<SocketQuitter>>,
 }
 
-/// A message pushed onto the bus when there's a new packet incoming from a socket.
-pub struct IncomingPacket<T>
-where
-   T: DeserializeOwned,
-{
-   pub token: ConnectionToken,
-   pub data: T,
-}
-
-/// A message to the network subsystem that a packet should be sent with the given data.
-enum SendPacket<T>
-where
-   T: DeserializeOwned + Serialize,
-{
-   Packet(IncomingPacket<T>),
-   Quit(ConnectionToken),
-}
-
-/// A message asking the rx thread with associated token to shut down.
-struct QuitReceive(ConnectionToken);
-
-/// A trait describing a valid, (de)serializable, owned packet.
-pub trait Packet: 'static + Send + DeserializeOwned + Serialize {}
-
-/// A unique handle to a socket.
-//
-// These handles cannot be cloned or copied, as each handle owns a single socket thread.
-// Once a handle is dropped, its associated thread is also asked to quit, and joined to the calling
-// thread.
-pub struct Socket<T>
-where
-   T: 'static + Send + DeserializeOwned + Serialize + Debug,
-{
-   token: ConnectionToken,
-   system: Arc<SocketSystem<T>>,
-   thread_slot: usize,
-}
-
-impl<T> Socket<T>
-where
-   T: 'static + Send + DeserializeOwned + Serialize + Debug,
-{
-   /// Returns the socket's connection token.
-   pub fn token(&self) -> ConnectionToken {
-      self.token
-   }
-
-   /// Issues a request that a packet with the provided data should be serialized and sent over the
-   /// socket.
-   pub fn send(&self, data: T) {
-      bus::push(SendPacket::Packet(IncomingPacket {
-         token: self.token,
-         data,
-      }))
-   }
-}
-
-impl<T> Drop for Socket<T>
-where
-   T: 'static + Send + DeserializeOwned + Serialize + Debug,
-{
-   fn drop(&mut self) {
-      bus::push(SendPacket::Quit::<T>(self.token));
-
-      let mut system_inner = self.system.inner.lock().unwrap();
-      let (receiving, sending) = system_inner.socket_threads[self.thread_slot].take().unwrap();
-      receiving.join().expect("receiving thread panicked");
-      sending.join().expect("sending thread panicked");
-   }
-}
-
-/// A socket handling subsystem for the given packet type `T`.
-pub struct SocketSystem<T>
-where
-   T: 'static + Send + DeserializeOwned + Serialize + Debug,
-{
-   inner: Mutex<SocketSystemInner<T>>,
-}
-
-static CONNECTION_TOKEN: Token = Token::new(0);
-
-impl<T> SocketSystem<T>
-where
-   T: 'static + Send + DeserializeOwned + Serialize + Debug,
-{
+impl SocketSystem {
+   /// Starts the socket system.
    pub fn new() -> Arc<Self> {
       Arc::new(Self {
-         inner: Mutex::new(SocketSystemInner::new()),
+         runtime: tokio::runtime::Builder::new_multi_thread().enable_io().build().unwrap(),
+         quitters: Mutex::new(Vec::new()),
       })
    }
 
-   fn resolve_address_with_default_port(
-      address: &str,
-      default_port: u16,
-   ) -> anyhow::Result<Vec<SocketAddr>> {
-      Ok(if let Ok(addresses) = address.to_socket_addrs() {
-         addresses.collect()
+   /// Resolves the socket addresses the given hostname could refer to.
+   async fn resolve_address_with_default_port(hostname: &str) -> anyhow::Result<Vec<SocketAddr>> {
+      if let Ok(addresses) = lookup_host(hostname).await {
+         Ok(addresses.collect())
       } else {
-         (address, default_port).to_socket_addrs()?.collect()
-      })
-   }
-
-   pub fn connect(
-      self: &Arc<Self>,
-      address: String,
-      default_port: u16,
-   ) -> anyhow::Result<ConnectionToken> {
-      let token = ConnectionToken(CONNECTION_TOKEN.next());
-
-      let this = Arc::clone(self);
-      thread::Builder::new().name("network connection thread".into()).spawn(move || {
-         let thread_slot = {
-            let mut inner = this.inner.lock().unwrap();
-            let addresses = catch!(Self::resolve_address_with_default_port(
-               &address,
-               default_port
-            ));
-            catch!(inner.connect(token, &addresses[..]))
-         };
-         let socket = Socket {
-            token,
-            system: this,
-            thread_slot,
-         };
-         bus::push(Connected { token, socket });
-      })?;
-
-      Ok(token)
-   }
-}
-
-/// A socket slot containing join handles for the receiving and sending thread, respectively.
-type Slot = Option<(JoinHandle<()>, JoinHandle<()>)>;
-
-/// The inner, non thread-safe data of `SocketSystem`.
-struct SocketSystemInner<T>
-where
-   T: 'static + Send + DeserializeOwned + Serialize + Debug,
-{
-   socket_threads: Vec<Slot>,
-   _phantom_data: PhantomData<T>,
-}
-
-impl<T> SocketSystemInner<T>
-where
-   T: 'static + Send + DeserializeOwned + Serialize + Debug,
-{
-   // This "inner" version of SocketSystem contains methods that operate on the inner vec of socket
-   // threads. These are "raw" versions of the public, safe API.
-
-   fn new() -> Self {
-      Self {
-         socket_threads: Vec::new(),
-         _phantom_data: PhantomData,
+         Ok(lookup_host((hostname, relay::DEFAULT_PORT)).await?.collect())
       }
    }
 
-   fn find_free_slot(&self) -> Option<usize> {
-      self.socket_threads.iter().position(|slot| slot.is_none())
+   async fn connect_inner(self: Arc<Self>, hostname: String) -> anyhow::Result<Socket> {
+      let addresses = Self::resolve_address_with_default_port(&hostname)
+         .await
+         .context("Could not resolve address. Are you sure the IP is correct?")?;
+      let (read_half, write_half) = TcpStream::connect(addresses.as_slice()).await?.into_split();
+
+      let (recv_tx, recv_rx) = mpsc::unbounded_channel();
+      let (recv_quit_tx, recv_quit_rx) = oneshot::channel();
+      let recv_join_handle = self.runtime.spawn(async move {
+         Socket::receiver_loop(read_half, recv_tx, recv_quit_rx).await.unwrap()
+      });
+
+      let (send_tx, send_rx) = mpsc::unbounded_channel();
+      let (send_quit_tx, send_quit_rx) = oneshot::channel();
+      let send_join_handle = self.runtime.spawn(async move {
+         Socket::sender_loop(write_half, send_rx, send_quit_rx).await.unwrap()
+      });
+
+      let mut quitters = self.quitters.lock().await;
+      quitters.push(SocketQuitter {
+         quit_send: send_quit_tx,
+         quit_recv: recv_quit_tx,
+         send_join_handle,
+         recv_join_handle,
+      });
+
+      Ok(Socket {
+         tx: send_tx,
+         rx: recv_rx,
+      })
    }
 
-   fn connect(
-      &mut self,
-      token: ConnectionToken,
-      address: impl ToSocketAddrs,
-   ) -> anyhow::Result<usize> {
-      let stream = TcpStream::connect(address)?;
-      stream.set_nodelay(true)?;
-
-      const KILOBYTE: usize = 1024;
-
-      // Reading and writing is buffered so as not to slow down performance when big packets are sent.
-
-      let reader = stream.try_clone()?; // BufReader::with_capacity(64 * KILOBYTE, stream.try_clone()?);
-      let receiving_thread =
-         thread::Builder::new().name("network receiving thread".into()).spawn(move || loop {
-            // Quit when the owning socket's dropped.
-            for message in &bus::retrieve_all::<QuitReceive>() {
-               if message.0 == token {
-                  message.consume();
-                  return;
-               }
-            }
-            // Read packets from the stream. `deserialize_from` will block until a packet is read successfully.
-            let data: T = catch!(bincode::deserialize_from(&reader));
-            bus::push(IncomingPacket { token, data });
-         })?;
-
-      let mut writer = BufWriter::with_capacity(64 * KILOBYTE, stream.try_clone()?);
-      let sending_thread =
-         thread::Builder::new().name("network sending thread".into()).spawn(move || loop {
-            let message = bus::wait_for::<SendPacket<T>>();
-            match &*message {
-               // Serialize and send the packet.
-               SendPacket::Packet(packet) if packet.token == token => {
-                  let data = catch!(bincode::serialize(&packet.data));
-                  let length = [
-                     (data.len() >> 24) as u8,
-                     (data.len() >> 16) as u8,
-                     (data.len() >> 8) as u8,
-                     (data.len()) as u8,
-                  ];
-                  catch!(writer.write_all(&length));
-                  catch!(writer.write_all(&data));
-                  catch!(writer.flush());
-                  message.consume();
-               }
-               // Quit when the owning socket is dropped.
-               SendPacket::Quit(quit_token) if *quit_token == token => {
-                  // The read stream is most certainly still blocking, trying to read a packet.
-                  // Thus, we shutdown the stream completely, which should make it stop reading.
-                  catch!(stream.shutdown(Shutdown::Both));
-                  message.consume();
-                  return;
-               }
-               _ => (),
-            }
-         })?;
-
-      Ok(match self.find_free_slot() {
-         Some(slot) => {
-            self.socket_threads[slot] = Some((receiving_thread, sending_thread));
-            slot
+   /// Initiates a new connection to the relay at the given hostname (IP address or DNS domain).
+   pub fn connect(self: Arc<Self>, hostname: String) -> oneshot::Receiver<anyhow::Result<Socket>> {
+      let (socket_tx, socket_rx) = oneshot::channel();
+      let self2 = Arc::clone(&self);
+      self.runtime.spawn(async move {
+         if let Err(_) = socket_tx.send(self2.connect_inner(hostname).await) {
+            panic!("Could not send ready socket to receiver");
          }
-         None => {
-            let slot = self.socket_threads.len();
-            self.socket_threads.push(Some((receiving_thread, sending_thread)));
-            slot
+      });
+      socket_rx
+   }
+}
+
+impl Drop for SocketSystem {
+   fn drop(&mut self) {
+      println!("cleaning up remaining sockets");
+      self.runtime.block_on(async {
+         let mut handles = self.quitters.lock().await;
+         for handle in handles.drain(..) {
+            handle.quit().await;
          }
       })
+   }
+}
+
+pub struct Socket {
+   tx: mpsc::UnboundedSender<relay::Packet>,
+   rx: mpsc::UnboundedReceiver<relay::Packet>,
+}
+
+impl Socket {
+   async fn read_packet(
+      read_half: &mut tcp::OwnedReadHalf,
+      len: usize,
+      output: &mut mpsc::UnboundedSender<relay::Packet>,
+   ) -> anyhow::Result<()> {
+      let mut bytes = vec![0; len as usize];
+      read_half.read_exact(&mut bytes).await?;
+      let packet = bincode::deserialize(&bytes).context("Invalid packet")?;
+      output.send(packet)?;
+      Ok(())
+   }
+
+   async fn receiver_loop(
+      mut read_half: tcp::OwnedReadHalf,
+      mut output: mpsc::UnboundedSender<relay::Packet>,
+      mut quit: oneshot::Receiver<Quit>,
+   ) -> anyhow::Result<()> {
+      loop {
+         tokio::select! {
+            biased;
+            Ok(_) = &mut quit => {
+               println!("receiver: received quit signal");
+               break;
+            },
+            len = read_half.read_u32() => Self::read_packet(
+               &mut read_half,
+               len? as usize,
+               &mut output
+            ).await?,
+            else => (),
+         }
+      }
+      println!("receiver loop done");
+      Ok(())
+   }
+
+   async fn write_packet(
+      write_half: &mut tcp::OwnedWriteHalf,
+      packet: relay::Packet,
+   ) -> anyhow::Result<()> {
+      let bytes = bincode::serialize(&packet)?;
+      write_half.write_u32(u32::try_from(bytes.len()).context("Packet is too big (wtf)")?).await?;
+      write_half.write_all(&bytes).await?;
+      Ok(())
+   }
+
+   async fn sender_loop(
+      mut write_half: tcp::OwnedWriteHalf,
+      mut input: mpsc::UnboundedReceiver<relay::Packet>,
+      mut quit: oneshot::Receiver<Quit>,
+   ) -> anyhow::Result<()> {
+      loop {
+         tokio::select! {
+            biased;
+            Ok(_) = &mut quit => {
+               println!("sender: received quit signal");
+               break;
+            },
+            packet = input.recv() => {
+               if let Some(packet) = packet {
+                  Self::write_packet(&mut write_half, packet).await?;
+               } else {
+                  break;
+               }
+            },
+            else => (),
+         }
+      }
+      println!("sender loop done");
+      Ok(())
+   }
+
+   /// Sends a packet to the receiving end of the socket.
+   pub fn send(&self, packet: relay::Packet) -> anyhow::Result<()> {
+      Ok(self.tx.send(packet).context("Attempt to write to a closed socket")?)
+   }
+
+   /// Receives packets from the sending end of the socket.
+   pub fn recv(&mut self) -> Option<relay::Packet> {
+      self.rx.try_recv().ok()
+   }
+}
+
+struct Quit;
+
+struct SocketQuitter {
+   quit_send: oneshot::Sender<Quit>,
+   quit_recv: oneshot::Sender<Quit>,
+   send_join_handle: JoinHandle<()>,
+   recv_join_handle: JoinHandle<()>,
+}
+
+impl SocketQuitter {
+   async fn quit(self) {
+      let _ = self.quit_send.send(Quit);
+      let _ = self.quit_recv.send(Quit);
+      let _ = self.send_join_handle.await;
+      let _ = self.recv_join_handle.await;
    }
 }


### PR DESCRIPTION
Third time's the charm.

This version uses tokio + async because of `select!`. It isn't possible to select between two tasks using _only_ the standard library, which is a shame but it is what it is. And I don't feel like rewriting nysa to use async.

Besides I'm not a big fan of nysa anymore. I think it has some fundamental flaws that are better solved using an actor model like the one used in this new implementation.

Closes #90.