### PR TITLE
Replace glFramebufferTexture call with glFramebufferTexture2D

### DIFF
--- a/netcanv-renderer-opengl/src/framebuffer.rs
+++ b/netcanv-renderer-opengl/src/framebuffer.rs
@@ -61,7 +61,13 @@ impl Framebuffer {
          );
          framebuffer = gl.create_framebuffer().unwrap();
          gl.bind_framebuffer(glow::FRAMEBUFFER, Some(framebuffer));
-         gl.framebuffer_texture(glow::FRAMEBUFFER, glow::COLOR_ATTACHMENT0, Some(texture), 0);
+         gl.framebuffer_texture_2d(
+            glow::FRAMEBUFFER,
+            glow::COLOR_ATTACHMENT0,
+            glow::TEXTURE_2D,
+            Some(texture),
+            0,
+         );
          assert!(
             gl.check_framebuffer_status(glow::FRAMEBUFFER) == glow::FRAMEBUFFER_COMPLETE,
             "could not create framebuffer (framebuffer was incomplete)"


### PR DESCRIPTION
Netcanv used to use glFramebufferTexture, but this function is not available in OpenGL ES (and thus in WebGL), so instead it now uses glFramebufferTexture2D, which is pretty much the same thing.

This fix is known to you, because it's... well, your fix and it should be upstreamed long time ago.