### PR TITLE
Use instant crate for Instant

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -776,9 +776,9 @@ dependencies = [
 
 [[package]]
 name = "instant"
-version = "0.1.9"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61124eeebbd69b8190558df225adf7e4caafce0d743919e5d6b19652314ec5ec"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -1066,6 +1066,7 @@ dependencies = [
  "directories",
  "heapless",
  "image",
+ "instant",
  "log",
  "native-dialog",
  "netcanv-protocol",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ directories = "3.0.2"
 tempfile = "3.3.0"
 toml = "0.5.8"
 url = "2.2.2"
+instant = "0.1.12"
 
 # Clipboard
 arboard = "2.0.1"

--- a/src/app/paint/actions/save_to_file.rs
+++ b/src/app/paint/actions/save_to_file.rs
@@ -1,6 +1,6 @@
 //! The `Save to file` action.
 
-use std::time::{Duration, Instant};
+use instant::{Duration, Instant};
 
 use native_dialog::FileDialog;
 

--- a/src/app/paint/mod.rs
+++ b/src/app/paint/mod.rs
@@ -7,7 +7,7 @@ mod tools;
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use instant::{Duration, Instant};
 
 use netcanv_protocol::relay::PeerId;
 use netcanv_renderer::paws::{

--- a/src/app/paint/tools/brush.rs
+++ b/src/app/paint/tools/brush.rs
@@ -1,7 +1,7 @@
 //! The Brush tool. Allows for painting, as well as erasing pixels from the canvas.
 
+use instant::Instant;
 use std::collections::HashMap;
-use std::time::Instant;
 
 use crate::backend::winit::event::MouseButton;
 use crate::config::config;

--- a/src/app/paint/tools/selection.rs
+++ b/src/app/paint/tools/selection.rs
@@ -1,6 +1,6 @@
+use instant::Instant;
 use std::collections::HashMap;
 use std::io::Cursor;
-use std::time::Instant;
 
 use crate::backend::winit::event::MouseButton;
 use crate::backend::winit::window::CursorIcon;

--- a/src/net/timer.rs
+++ b/src/net/timer.rs
@@ -1,6 +1,6 @@
 //! Configurable, framerate-independent timer for use in `process()`.
 
-use std::time::{Duration, Instant};
+use instant::{Duration, Instant};
 
 /// A framerate-independent timer.
 pub struct Timer {

--- a/src/ui/input.rs
+++ b/src/ui/input.rs
@@ -1,7 +1,7 @@
 //! Simplified input handling facility.
 
 use std::ops::{BitAnd, BitOr};
-use std::time::Instant;
+use instant::Instant;
 
 use crate::backend::winit::dpi::PhysicalPosition;
 pub use crate::backend::winit::event::{ElementState, MouseButton, VirtualKeyCode};


### PR DESCRIPTION
std::time::Instant does not support wasm. However, there is a crate called instant that provides this functionality for wasm, and for other platforms it is a simple alias for std::time.