### PR TITLE
aarch64 builds + executable cosmetics

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.aarch64-unknown-linux-gnu]
+linker = "aarch64-linux-gnu-gcc"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -28,6 +28,7 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get install -y libxcb-shape0-dev libxcb-xfixes0-dev libxkbcommon-dev
+        sudo apt-get install -y gcc-aarch64-linux-gnu
         cargo install cargo-about || true
         rustup target add aarch64-unknown-linux-gnu
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -83,9 +83,7 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         name: netcanv-nightly-windows
-        path: |
-          target/release/netcanv.exe
-          target/release/netcanv-relay.exe
+        path: bin
 
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,7 +12,7 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build-appimage:
+  build-linux:
     runs-on: ubuntu-18.04
 
     steps:
@@ -52,7 +52,7 @@ jobs:
         name: netcanv-nightly-linux
         path: bin
 
-  build-exe:
+  build-windows:
     runs-on: windows-latest
 
     steps:
@@ -91,7 +91,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     if: github.event_name == 'Release' && github.event.action == 'Created'
-    needs: [build-appimage, build-exe]
+    needs: [build-linux, build-windows]
 
     steps:
     - name: Download all artifacts

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -31,6 +31,9 @@ jobs:
         cargo install cargo-about || true
         rustup target add aarch64-unknown-linux-gnu
 
+    - name: Set up directories
+      run: mkdir bin
+
     - name: Compile application
       run: cargo build --release
     - name: Compile relay

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -29,7 +29,7 @@ jobs:
       run: |
         sudo apt-get install -y libxcb-shape0-dev libxcb-xfixes0-dev libxkbcommon-dev
         cargo install cargo-about || true
-        rustup toolchain add aarch64-unknown-linux-gnu
+        rustup target add aarch64-unknown-linux-gnu
 
     - name: Compile application
       run: cargo build --release

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -29,12 +29,16 @@ jobs:
       run: |
         sudo apt-get install -y libxcb-shape0-dev libxcb-xfixes0-dev libxkbcommon-dev
         cargo install cargo-about || true
+        rustup toolchain add aarch64-unknown-linux-gnu
 
     - name: Compile application
       run: cargo build --release
     - name: Compile relay
-      working-directory: netcanv-relay
-      run: cargo build --release
+      run: |
+        cargo build -p netcanv-relay --release
+        mv target/release/netcanv-relay bin/NetCanv-Relay-linux.$(uname -m)
+        cargo build -p netcanv-relay --release --target=aarch64-unknown-linux-gnu
+        mv target/aarch64-unknown-linux-gnu/release/netcanv-relay bin/NetCanv-Relay-linux.aarch64
 
     - name: Build AppImages
       run: bash build/appimages.sh
@@ -43,7 +47,7 @@ jobs:
       uses: actions/upload-artifact@v2.2.2
       with:
         name: netcanv-nightly-linux
-        path: appimages
+        path: bin
 
   build-exe:
     runs-on: windows-latest
@@ -68,8 +72,12 @@ jobs:
       working-directory: netcanv-relay
       run: cargo build --release
 
-    - name: Apply icons to executables
-      run: ./build/windows-icons.ps1
+    - name: Apply cosmetics to executables
+      run: |
+        ./build/windows-icons.ps1
+        mkdir bin
+        move target/release/netcanv.exe bin/NetCanv-windows-x86_64.exe
+        move target/release/netcanv-relay.exe bin/NetCanv-Relay-windows-x86_64.exe
 
     - name: Upload artifacts
       uses: actions/upload-artifact@v2

--- a/build/appimages.sh
+++ b/build/appimages.sh
@@ -20,6 +20,5 @@ chmod +x linuxdeploy-x86_64.AppImage
   --desktop-file resources/netcanv.desktop \
   --output appimage
 
-mkdir bin
 mv NetCanv-*.AppImage bin/NetCanv-linux-$(uname -m).AppImage
 rm -r NetCanv*-AppDir

--- a/build/appimages.sh
+++ b/build/appimages.sh
@@ -20,17 +20,6 @@ chmod +x linuxdeploy-x86_64.AppImage
   --desktop-file resources/netcanv.desktop \
   --output appimage
 
-./linuxdeploy-x86_64.AppImage \
-  --appdir NetCanv-Relay-AppDir \
-  --executable target/release/netcanv-relay \
-  --icon-file resources/icon/16/netcanv.png \
-  --icon-file resources/icon/32/netcanv.png \
-  --icon-file resources/icon/64/netcanv.png \
-  --icon-file resources/icon/128/netcanv.png \
-  --icon-file resources/icon/256/netcanv.png \
-  --desktop-file resources/netcanv-relay.desktop \
-  --output appimage
-
-mkdir appimages
-mv NetCanv-*.AppImage NetCanv_Relay-*.AppImage appimages
+mkdir bin
+mv NetCanv-*.AppImage bin/NetCanv-linux-$(uname -m).AppImage
 rm -r NetCanv*-AppDir


### PR DESCRIPTION
This PR adds aarch64 builds to the CI. It also makes executable naming more consistent.