### PR TITLE
Send periodic heartbeat packets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1294,7 +1294,7 @@ dependencies = [
 
 [[package]]
 name = "netcanv-relay"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "anyhow",
  "bincode",

--- a/netcanv-relay/Cargo.toml
+++ b/netcanv-relay/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "netcanv-relay"
-version = "2.1.0"
+version = "2.1.1"
 edition = "2021"
 
 [dependencies]

--- a/netcanv-relay/src/main.rs
+++ b/netcanv-relay/src/main.rs
@@ -400,7 +400,6 @@ async fn ping_loop(write: Arc<Mutex<Sink>>) -> anyhow::Result<()> {
    const PING_PERIOD: Duration = Duration::from_secs(5);
    loop {
       tokio::time::sleep(PING_PERIOD).await;
-      log::debug!("ping jong un");
       write.lock().await.send(Message::Ping(PING_MESSAGE.as_bytes().to_owned())).await?;
    }
 }

--- a/netcanv-relay/src/main.rs
+++ b/netcanv-relay/src/main.rs
@@ -4,6 +4,7 @@
 use std::collections::{HashMap, HashSet};
 use std::net::{Ipv4Addr, SocketAddr};
 use std::sync::Arc;
+use std::time::Duration;
 
 use anyhow::Context;
 use futures_util::stream::{SplitSink, SplitStream};
@@ -352,6 +353,7 @@ async fn read_packets(
                return Ok(());
             }
          }
+         Ok(Message::Pong(_)) => {}
          Ok(_) => log::info!("got ignored message"),
          Err(e) => {
             use tungstenite::Error::*;
@@ -391,6 +393,18 @@ async fn transfer_host(state: &mut State, room_id: RoomId) -> anyhow::Result<()>
    Ok(())
 }
 
+/// Pings the sink periodically.
+async fn ping_loop(write: Arc<Mutex<Sink>>) -> anyhow::Result<()> {
+   // This loop is exited whenever the stream is closed.
+   const PING_MESSAGE: &str = concat!("PING NetCanv Relay ", env!("CARGO_PKG_VERSION"));
+   const PING_PERIOD: Duration = Duration::from_secs(5);
+   loop {
+      tokio::time::sleep(PING_PERIOD).await;
+      log::debug!("ping jong un");
+      write.lock().await.send(Message::Ping(PING_MESSAGE.as_bytes().to_owned())).await?;
+   }
+}
+
 async fn handle_connection(
    stream: TcpStream,
    address: SocketAddr,
@@ -408,10 +422,22 @@ async fn handle_connection(
    write.send(tungstenite::Message::binary(version)).await?;
    let write = Arc::new(Mutex::new(write));
 
+   let pinger = {
+      let write = Arc::clone(&write);
+      tokio::spawn(async move {
+         if let Err(error) = ping_loop(write).await {
+            log::error!("[{}] ping loop: {}", address, error);
+         }
+      })
+   };
+
    match read_packets(read, write, address, &state).await {
       Ok(()) => (),
       Err(error) => log::error!("[{}] connection error: {}", address, error),
    }
+
+   // Abort the pinger if it hasn't already exited.
+   pinger.abort();
 
    log::info!("tearing down {}'s connection", address);
    {


### PR DESCRIPTION
This is a (mostly) backwards-compatible change that adds WebSocket ping/pong message support. These messages are sent periodically every 5 seconds to prevent reverse proxies like nginx from closing the connection from a lack of traffic.

Closes #137.