### PR TITLE
 Remember that a window was maximized in addition to its size and position

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2781,12 +2781,11 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winit"
-version = "0.26.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70466a5f4825cc88c92963591b06dbc255420bffe19d847bfcda475e82d079c0"
+checksum = "9b43cc931d58b99461188607efd7acb2a093e65fc621f54cad78517a6063e73a"
 dependencies = [
  "bitflags",
- "block",
  "cocoa",
  "core-foundation 0.9.1",
  "core-graphics 0.22.2",

--- a/netcanv-renderer-opengl/Cargo.toml
+++ b/netcanv-renderer-opengl/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.40"
-winit = { version = "0.26.0", features = ["serde"] }
+winit = { version = "0.26.1", features = ["serde"] }
 glutin = "0.28.0"
 glow = "0.11.0"
 memoffset = "0.6.4"

--- a/src/config.rs
+++ b/src/config.rs
@@ -63,6 +63,7 @@ pub struct WindowConfig {
    pub y: i32,
    pub width: u32,
    pub height: u32,
+   pub maximized: bool,
 }
 
 /// A user `config.toml` file.


### PR DESCRIPTION
Closes #136.

The config should now contain the last position and size of the window before maximization, and whether the window was maximized or not when closed.

I also updated winit, which fixed one of the bugs with `WindowBuilder::with_maximized()`, but not *that* one.

- [ ] Tested on:
  - [x] Windows
  - [ ] X11
  - [ ] Wayland
  - [ ] Anything else?

NOTE: [WindowBuilder::with_maximized()](https://docs.rs/winit/0.26.1/winit/window/struct.WindowBuilder.html#method.with_maximized) is buggy.