### PR TITLE
Fix incorrect OpenGL ES 3 code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -791,9 +791,9 @@ checksum = "2b8509e6791516e81c1a630d0bd7fbac36d2fa8712a9da8662e716b52d5051ca"
 
 [[package]]
 name = "glow"
-version = "0.11.0"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f04649123493bc2483cbef4daddb45d40bbdae5adb221a63a23efdb0cc99520"
+checksum = "d8bd5877156a19b8ac83a29b2306fe20537429d318f3ff0a1a2119f8d9c61919"
 dependencies = [
  "js-sys",
  "slotmap",

--- a/netcanv-renderer-opengl/Cargo.toml
+++ b/netcanv-renderer-opengl/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 anyhow = "1.0.40"
 winit = { version = "0.27.4", features = ["serde"] }
 glutin = "0.29.1"
-glow = "0.11.0"
+glow = "0.11.2"
 memoffset = "0.6.4"
 freetype-rs = "0.26.0"
 smallvec = { version = "1.7.0", features = ["const_generics"] }

--- a/netcanv-renderer-opengl/src/font.rs
+++ b/netcanv-renderer-opengl/src/font.rs
@@ -80,7 +80,7 @@ impl FontFace {
          gl.tex_image_2d(
             glow::TEXTURE_2D,
             0,
-            glow::RED as i32,
+            glow::R8 as i32,
             TEXTURE_ATLAS_SIZE as i32,
             TEXTURE_ATLAS_SIZE as i32,
             0,

--- a/netcanv-renderer-opengl/src/image.rs
+++ b/netcanv-renderer-opengl/src/image.rs
@@ -57,12 +57,12 @@ impl Image {
          gl.tex_parameter_i32(
             glow::TEXTURE_2D,
             glow::TEXTURE_WRAP_S,
-            glow::CLAMP_TO_BORDER as i32,
+            glow::CLAMP_TO_EDGE as i32,
          );
          gl.tex_parameter_i32(
             glow::TEXTURE_2D,
             glow::TEXTURE_WRAP_T,
-            glow::CLAMP_TO_BORDER as i32,
+            glow::CLAMP_TO_EDGE as i32,
          );
          let texture = Rc::new(TextureHandle { gl, texture });
          Self {


### PR DESCRIPTION
Some parts of the code weren't following OpenGL ES 3 standard correctly. While it was working for the desktop, it showed errors when ported to web browsers.
Hopefully, those fixes are really simple and should not change behavior.

Details:

- glTexImage2D in FontFace::make_size now uses GL_R8 as internalFormat, because GL_RED is not a valid value, according to specification.[^1]
- glTexParameteri in Image::from_rgba now uses GL_CLAMP_TO_EDGE instead of GL_CLAMP_TO_BORDER as param for GL_TEXTURE_WRAP_S and GL_TEXTURE_WRAP_T, because GL_CLAM_TO_BORDER is not supported in OpenGL ES 3, according to specification.[^2]

[^1]: "Table 2. Sized Internal Formats": https://docs.gl/es3/glTexImage2D
[^2]: In description for GL_TEXTURE_WRAP_S and GL_TEXTURE_WRAP_T: https://docs.gl/es3/glTexParameter