### PR TITLE
Fix crash on pasting text into text field

### DIFF
--- a/src/ui/text_field.rs
+++ b/src/ui/text_field.rs
@@ -419,13 +419,9 @@ impl TextField {
          if input.action(config().keymap.edit.paste) == (true, true) {
             if let Ok(clipboard) = clipboard::paste_string() {
                let clipboard = clipboard.replace('\n', " ");
-               let cursor = self.selection.cursor();
+               let start = self.selection.start();
                self.text.replace_range(self.selection.normalize(), &clipboard);
-               self.selection.move_to(TextPosition(cursor + clipboard.len()));
-
-               if self.selection.cursor() > self.text.len() {
-                  self.selection.move_to(TextPosition(self.text.len()))
-               }
+               self.selection.move_to(TextPosition(start + clipboard.len()));
             }
          }
 

--- a/src/ui/text_field.rs
+++ b/src/ui/text_field.rs
@@ -422,6 +422,10 @@ impl TextField {
                let cursor = self.selection.cursor();
                self.text.replace_range(self.selection.normalize(), &clipboard);
                self.selection.move_to(TextPosition(cursor + clipboard.len()));
+
+               if self.selection.cursor() > self.text.len() {
+                  self.selection.move_to(TextPosition(self.text.len()))
+               }
             }
          }
 


### PR DESCRIPTION
Code responsible for rendering the flashing cursor in text fields was getting position which was out of pasted text bounds what leaded to crashing. It was fixed by using the selection start position instead of the selection cursor position when pasting text and moving the cursor.