### PR TITLE
Upgrade swash to 0.1.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2404,9 +2404,9 @@ dependencies = [
 
 [[package]]
 name = "swash"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bb18e5888a9b5f0a89ea3ebdf6883dc479347ca9183b6c51a8f9cf2041f23a0"
+checksum = "3b7c73c813353c347272919aa1af2885068b05e625e5532b43049e4f641ae77f"
 dependencies = [
  "yazi",
  "zeno",
@@ -3346,9 +3346,9 @@ checksum = "ec7a2a501ed189703dba8b08142f057e887dfc4b2cc4db2d343ac6376ba3e0b9"
 
 [[package]]
 name = "yazi"
-version = "0.1.4"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c03b3e19c937b5b9bd8e52b1c88f30cce5c0d33d676cf174866175bb794ff658"
+checksum = "c94451ac9513335b5e23d7a8a2b61a7102398b8cca5160829d313e84c9d98be1"
 
 [[package]]
 name = "zeno"

--- a/netcanv-renderer-opengl/Cargo.toml
+++ b/netcanv-renderer-opengl/Cargo.toml
@@ -9,7 +9,7 @@ winit = { version = "0.27.4", features = ["serde"] }
 glutin = "0.29.1"
 glow = "0.11.2"
 memoffset = "0.6.4"
-swash = "0.1.6"
+swash = "0.1.8"
 smallvec = { version = "1.7.0", features = ["const_generics"] }
 glam = "0.19.0"
 


### PR DESCRIPTION
Seems like 0.1.6 doesn't seem to work on latest Rust, since misaligned pointer dereference checks were introduced.