### PR TITLE
Move chunk encoding and decoding out of ImageCoder

### DIFF
--- a/src/app/paint/mod.rs
+++ b/src/app/paint/mod.rs
@@ -176,8 +176,14 @@ impl State {
          update_timer: Timer::new(Self::TIME_PER_UPDATE),
          chunk_downloads: HashMap::new(),
          encoded_chunks: HashMap::new(),
-         encode_channels: EncodeChannels { tx: encoded_tx, rx: encoded_rx },
-         decode_channels: DecodeChannels { tx: decoded_tx, rx: decoded_rx },
+         encode_channels: EncodeChannels {
+            tx: encoded_tx,
+            rx: encoded_rx,
+         },
+         decode_channels: DecodeChannels {
+            tx: decoded_tx,
+            rx: decoded_rx,
+         },
 
          fatal_error: false,
          log: Log::new(),
@@ -288,11 +294,9 @@ impl State {
          match ImageCoder::decode_network_data(&image_data) {
             Ok(image) => {
                // Doesn't matter if the receiving half is closed.
-               tx
-                  .send((chunk_position, image))
-                  .expect("Unbounded send failed");
+               tx.send((chunk_position, image)).expect("Unbounded send failed");
             }
-            Err(error) => tracing::error!("image decoding failed: {:?}", error)
+            Err(error) => tracing::error!("image decoding failed: {:?}", error),
          }
       });
    }
@@ -418,7 +422,7 @@ impl State {
       // Rendering
       //
 
-      while let Ok((chunk_position ,image)) = self.decode_channels.rx.try_recv() {
+      while let Ok((chunk_position, image)) = self.decode_channels.rx.try_recv() {
          self.paint_canvas.set_chunk(ui, chunk_position, image);
       }
       while let Ok((chunk_position, image)) = self.encode_channels.rx.try_recv() {

--- a/src/app/paint/mod.rs
+++ b/src/app/paint/mod.rs
@@ -4,6 +4,7 @@ mod actions;
 pub mod tool_bar;
 mod tools;
 
+use image::RgbaImage;
 use instant::{Duration, Instant};
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -26,7 +27,7 @@ use crate::assets::*;
 use crate::backend::Backend;
 use crate::clipboard;
 use crate::common::*;
-use crate::image_coder::{ImageCoder, ImageCoderChannels};
+use crate::image_coder::ImageCoder;
 use crate::net::peer::{self, Peer};
 use crate::net::socket::SocketSystem;
 use crate::net::timer::Timer;
@@ -80,6 +81,11 @@ struct EncodeChannels {
    rx: mpsc::UnboundedReceiver<((i32, i32), CachedChunk)>,
 }
 
+struct DecodeChannels {
+   tx: mpsc::UnboundedSender<((i32, i32), RgbaImage)>,
+   rx: mpsc::UnboundedReceiver<((i32, i32), RgbaImage)>,
+}
+
 /// The paint app state.
 pub struct State {
    assets: Box<Assets>,
@@ -87,8 +93,6 @@ pub struct State {
    project_file: ProjectFile,
 
    paint_canvas: PaintCanvas,
-   xcoder: ImageCoder,
-   xcoder_channels: ImageCoderChannels,
    cache_layer: CacheLayer,
 
    actions: Vec<Box<dyn actions::Action>>,
@@ -97,6 +101,8 @@ pub struct State {
    update_timer: Timer,
    chunk_downloads: HashMap<(i32, i32), ChunkDownload>,
    encoded_chunks: HashMap<PeerId, EncodeChannels>,
+   encode_channels: EncodeChannels,
+   decode_channels: DecodeChannels,
 
    fatal_error: bool,
    log: Log,
@@ -152,8 +158,8 @@ impl State {
       image_path: Option<PathBuf>,
       renderer: &mut Backend,
    ) -> Result<Self, (netcanv::Error, Box<Assets>)> {
-      // Set up decoding supervisor thread.
-      let (xcoder, channels) = ImageCoder::new();
+      let (encoded_tx, encoded_rx) = mpsc::unbounded_channel();
+      let (decoded_tx, decoded_rx) = mpsc::unbounded_channel();
 
       let mut wm = WindowManager::new();
       let mut this = Self {
@@ -161,8 +167,6 @@ impl State {
          socket_system,
 
          paint_canvas: PaintCanvas::new(),
-         xcoder,
-         xcoder_channels: channels,
          cache_layer: CacheLayer::new(),
          project_file: ProjectFile::new(),
 
@@ -172,6 +176,8 @@ impl State {
          update_timer: Timer::new(Self::TIME_PER_UPDATE),
          chunk_downloads: HashMap::new(),
          encoded_chunks: HashMap::new(),
+         encode_channels: EncodeChannels { tx: encoded_tx, rx: encoded_rx },
+         decode_channels: DecodeChannels { tx: decoded_tx, rx: decoded_rx },
 
          fatal_error: false,
          log: Log::new(),
@@ -277,7 +283,18 @@ impl State {
 
    /// Decodes canvas data to the given chunk.
    fn decode_canvas_data(&mut self, chunk_position: (i32, i32), image_data: Vec<u8>) {
-      self.xcoder.enqueue_chunk_decoding(chunk_position, image_data);
+      let tx = self.decode_channels.tx.clone();
+      tokio::task::spawn_blocking(move || {
+         match ImageCoder::decode_network_data(&image_data) {
+            Ok(image) => {
+               // Doesn't matter if the receiving half is closed.
+               tx
+                  .send((chunk_position, image))
+                  .expect("Unbounded send failed");
+            }
+            Err(error) => tracing::error!("image decoding failed: {:?}", error)
+         }
+      });
    }
 
    /// Processes the message log.
@@ -401,10 +418,10 @@ impl State {
       // Rendering
       //
 
-      while let Ok((chunk_position, image)) = self.xcoder_channels.decoded_chunks_rx.try_recv() {
+      while let Ok((chunk_position ,image)) = self.decode_channels.rx.try_recv() {
          self.paint_canvas.set_chunk(ui, chunk_position, image);
       }
-      while let Ok((chunk_position, image)) = self.xcoder_channels.encoded_chunks_rx.try_recv() {
+      while let Ok((chunk_position, image)) = self.encode_channels.rx.try_recv() {
          let _ = self.paint_canvas.ensure_chunk(ui, chunk_position);
          self.cache_layer.set_chunk(chunk_position, image);
       }
@@ -805,7 +822,7 @@ impl State {
             }
          }
          MessageKind::GetChunks(requester, positions) => {
-            self.enqueue_chunks_for_encoding(ui, requester, &positions);
+            self.encode_chunks(ui, requester, &positions);
          }
          MessageKind::Tool(sender, name, payload) => {
             if let Some(tool_id) = self.toolbar.tool_by_name(&name) {
@@ -852,7 +869,7 @@ impl State {
       Ok(())
    }
 
-   fn enqueue_chunks_for_encoding(
+   fn encode_chunks(
       &mut self,
       renderer: &mut Backend,
       requester: PeerId,
@@ -873,9 +890,38 @@ impl State {
          );
          // If there is a cached image already, there's no point in encoding it all over again.
          if let Some(chunk) = self.cache_layer.chunk(chunk_position) {
-            self.xcoder.send_encoded_chunk(chunk, tx.clone(), chunk_position);
+            tracing::debug!("reusing {:?}", chunk_position);
+            let _ = self.encode_channels.tx.send((chunk_position, chunk.to_owned()));
+            let _ = tx.send((chunk_position, chunk.to_owned()));
          } else if let Some(chunk) = self.paint_canvas.chunk(chunk_position) {
-            self.xcoder.enqueue_chunk_encoding(renderer, chunk, tx.clone(), chunk_position);
+            // If the chunk's image is empty, there's no point in sending it.
+            let image = chunk.download_image(renderer);
+            if Chunk::image_is_empty(&image) {
+               break;
+            }
+            // Otherwise, we can start encoding the chunk image.
+            let encoded_chunks_tx = self.encode_channels.tx.clone();
+            let tx = tx.clone();
+
+            tokio::spawn(async move {
+               tracing::debug!("encoding image data for chunk {:?}", chunk_position);
+               let image_data = ImageCoder::encode_network_data(image).await;
+               tracing::debug!("encoding done for chunk {:?}", chunk_position);
+               match image_data {
+                  Ok(data) => {
+                     tracing::debug!("sending image data back to main thread");
+                     let _ = encoded_chunks_tx.send((chunk_position, data.clone()));
+                     let _ = tx.send((chunk_position, data));
+                  }
+                  Err(error) => {
+                     tracing::error!(
+                        "error while encoding image for chunk {:?}: {:?}",
+                        chunk_position,
+                        error
+                     );
+                  }
+               }
+            });
          }
       }
    }
@@ -1006,7 +1052,5 @@ impl AppState for State {
       }
    }
 
-   fn exit(self: Box<Self>) {
-      tokio::spawn(self.xcoder.shutdown());
-   }
+   fn exit(self: Box<Self>) {}
 }

--- a/src/app/paint/mod.rs
+++ b/src/app/paint/mod.rs
@@ -897,7 +897,7 @@ impl State {
             // If the chunk's image is empty, there's no point in sending it.
             let image = chunk.download_image(renderer);
             if Chunk::image_is_empty(&image) {
-               break;
+               continue;
             }
             // Otherwise, we can start encoding the chunk image.
             let encoded_chunks_tx = self.encode_channels.tx.clone();

--- a/src/image_coder.rs
+++ b/src/image_coder.rs
@@ -4,62 +4,17 @@ use ::image::codecs::png::{PngDecoder, PngEncoder};
 use ::image::codecs::webp::{WebPDecoder, WebPEncoder, WebPQuality};
 use ::image::{ColorType, ImageDecoder, Rgba, RgbaImage};
 use image::{DynamicImage, ImageEncoder};
-use tokio::sync::{mpsc, oneshot};
-use tokio::task::JoinHandle;
 
-use crate::backend::Backend;
 use crate::paint_canvas::cache_layer::CachedChunk;
 use crate::paint_canvas::chunk::Chunk;
 use crate::Error;
 
-pub struct ImageCoderChannels {
-   pub decoded_chunks_rx: mpsc::UnboundedReceiver<((i32, i32), RgbaImage)>,
-   pub encoded_chunks_rx: mpsc::UnboundedReceiver<((i32, i32), CachedChunk)>,
-}
-
-pub struct ImageCoder {
-   decoder_quitter: Option<(oneshot::Sender<()>, JoinHandle<()>)>,
-
-   chunks_to_decode_tx: mpsc::UnboundedSender<((i32, i32), Vec<u8>)>,
-   encoded_chunks_tx: mpsc::UnboundedSender<((i32, i32), CachedChunk)>,
-}
+pub struct ImageCoder;
 
 impl ImageCoder {
    /// The maximum size threshold for a PNG to get converted to lossy WebP before network
    /// transmission.
    const MAX_PNG_SIZE: usize = 32 * 1024;
-
-   pub fn new() -> (Self, ImageCoderChannels) {
-      let (chunks_to_decode_tx, chunks_to_decode_rx) = mpsc::unbounded_channel();
-      let (decoded_chunks_tx, decoded_chunks_rx) = mpsc::unbounded_channel();
-      let (encoded_chunks_tx, encoded_chunks_rx) = mpsc::unbounded_channel();
-      let (decoder_quit_tx, decoder_quit_rx) = oneshot::channel();
-
-      let decode_join_handle = tokio::spawn({
-         async move {
-            ImageCoder::chunk_decoding_loop(
-               chunks_to_decode_rx,
-               decoded_chunks_tx,
-               decoder_quit_rx,
-            )
-            .await;
-         }
-      });
-
-      (
-         Self {
-            decoder_quitter: Some((decoder_quit_tx, decode_join_handle)),
-
-            chunks_to_decode_tx,
-
-            encoded_chunks_tx,
-         },
-         ImageCoderChannels {
-            decoded_chunks_rx,
-            encoded_chunks_rx,
-         },
-      )
-   }
 
    /// Encodes an image to PNG data asynchronously.
    pub async fn encode_png_data(image: RgbaImage) -> netcanv::Result<Vec<u8>> {
@@ -105,9 +60,10 @@ impl ImageCoder {
 
    /// Encodes a network image asynchronously. This encodes PNG, as well as WebP if the PNG is too
    /// large, and returns both images.
-   async fn encode_network_data(image: RgbaImage) -> netcanv::Result<CachedChunk> {
+   pub async fn encode_network_data(image: RgbaImage) -> netcanv::Result<CachedChunk> {
       let png = Self::encode_png_data(image.clone()).await?;
       let webp = if png.len() > Self::MAX_PNG_SIZE {
+         tracing::debug!("webp");
          Some(Self::encode_webp_data(image).await?)
       } else {
          None
@@ -136,7 +92,7 @@ impl ImageCoder {
 
    /// Decodes a PNG or WebP file into the given sub-chunk, depending on what's actually stored in
    /// `data`.
-   fn decode_network_data(data: &[u8]) -> netcanv::Result<RgbaImage> {
+   pub fn decode_network_data(data: &[u8]) -> netcanv::Result<RgbaImage> {
       // Try WebP first.
       let image = Self::decode_webp_data(data).or_else(|_| Self::decode_png_data(data))?;
       if image.dimensions() != Chunk::SIZE {
@@ -149,95 +105,5 @@ impl ImageCoder {
       } else {
          Ok(image)
       }
-   }
-
-   /// The decoding supervisor thread.
-   async fn chunk_decoding_loop(
-      mut input: mpsc::UnboundedReceiver<((i32, i32), Vec<u8>)>,
-      output: mpsc::UnboundedSender<((i32, i32), RgbaImage)>,
-      mut quit: oneshot::Receiver<()>,
-   ) {
-      tracing::info!("starting chunk decoding supervisor thread");
-      loop {
-         tokio::select! {
-            biased;
-            Ok(_) = &mut quit => break,
-            data = input.recv() => {
-               if let Some((chunk_position, image_data)) = data {
-                  let output = output.clone();
-                  tokio::task::spawn_blocking(move || match ImageCoder::decode_network_data(&image_data) {
-                     Ok(image) => {
-                        // Doesn't matter if the receiving half is closed.
-                        let _ = output.send((chunk_position, image));
-                     }
-                     Err(error) => tracing::error!("image decoding failed: {:?}", error),
-                  });
-               } else {
-                  tracing::info!("decoding supervisor: chunk data sender was dropped, quitting");
-                  break;
-               }
-            },
-         }
-      }
-      tracing::info!("exiting chunk decoding supervisor thread");
-   }
-
-   pub fn enqueue_chunk_encoding(
-      &self,
-      renderer: &mut Backend,
-      chunk: &Chunk,
-      output_channel: mpsc::UnboundedSender<((i32, i32), CachedChunk)>,
-      chunk_position: (i32, i32),
-   ) {
-      // If the chunk's image is empty, there's no point in sending it.
-      let image = chunk.download_image(renderer);
-      if Chunk::image_is_empty(&image) {
-         return;
-      }
-      // Otherwise, we can start encoding the chunk image.
-      let encoded_chunks_tx = self.encoded_chunks_tx.clone();
-
-      tokio::spawn(async move {
-         tracing::debug!("encoding image data for chunk {:?}", chunk_position);
-         let image_data = ImageCoder::encode_network_data(image).await;
-         tracing::debug!("encoding done for chunk {:?}", chunk_position);
-         match image_data {
-            Ok(data) => {
-               tracing::debug!("sending image data back to main thread");
-               let _ = encoded_chunks_tx.send((chunk_position, data.clone()));
-               let _ = output_channel.send((chunk_position, data));
-            }
-            Err(error) => {
-               tracing::error!(
-                  "error while encoding image for chunk {:?}: {:?}",
-                  chunk_position,
-                  error
-               );
-            }
-         }
-      });
-   }
-
-   pub fn enqueue_chunk_decoding(&self, to_chunk: (i32, i32), data: Vec<u8>) {
-      self
-         .chunks_to_decode_tx
-         .send((to_chunk, data))
-         .expect("Decoding supervisor thread should never quit");
-   }
-
-   pub fn send_encoded_chunk(
-      &self,
-      chunk: &CachedChunk,
-      output_channel: mpsc::UnboundedSender<((i32, i32), CachedChunk)>,
-      position: (i32, i32),
-   ) {
-      let _ = self.encoded_chunks_tx.send((position, chunk.to_owned()));
-      let _ = output_channel.send((position, chunk.to_owned()));
-   }
-
-   pub async fn shutdown(mut self) {
-      let (channel, join_handle) = self.decoder_quitter.take().unwrap();
-      let _ = channel.send(());
-      let _ = join_handle.await;
    }
 }


### PR DESCRIPTION
`ImageCoder`'s should do only decoding and encoding image formats, and chunk decoding and encoding in `ImageCoder` required various shenanigans, like creating `ImageCoder` in paint state and communicating with it via channels.

Thus, chunk decoding and encoding have been moved to `paint::State`, simplifying `ImageCoder`, so we can reuse it later in other areas where decoding/encoding PNG and WebP is needed.