### PR TITLE
Update dependencies in netcanv-relay

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1346,17 +1346,6 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
-dependencies = [
- "bytes",
- "fnv",
- "itoa",
-]
-
-[[package]]
-name = "http"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
@@ -1854,7 +1843,7 @@ dependencies = [
  "tempfile",
  "tiny-skia 0.5.1",
  "tokio",
- "tokio-tungstenite 0.23.1",
+ "tokio-tungstenite",
  "toml",
  "tracing",
  "tracing-chrome",
@@ -1904,11 +1893,12 @@ dependencies = [
  "log",
  "nanorand",
  "netcanv-protocol",
+ "rustls",
  "serde",
  "simple_logger",
  "structopt",
  "tokio",
- "tokio-tungstenite 0.20.1",
+ "tokio-tungstenite",
 ]
 
 [[package]]
@@ -3035,9 +3025,9 @@ checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
 name = "simple_logger"
-version = "4.3.3"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e7e46c8c90251d47d08b28b8a419ffb4aede0f87c2eea95e17d1d5bacbf3ef1"
+checksum = "e8c5dfa5e08767553704aa0ffd9d9794d527103c736aba9854773851fd7497eb"
 dependencies = [
  "colored",
  "log",
@@ -3508,18 +3498,6 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.20.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "212d5dcb2a1ce06d81107c3d0ffa3121fe974b73f068c8282cb1c32328113b6c"
-dependencies = [
- "futures-util",
- "log",
- "tokio",
- "tungstenite 0.20.1",
-]
-
-[[package]]
-name = "tokio-tungstenite"
 version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6989540ced10490aaf14e6bad2e3d33728a2813310a0c71d1574304c49631cd"
@@ -3531,7 +3509,7 @@ dependencies = [
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
- "tungstenite 0.23.0",
+ "tungstenite",
 ]
 
 [[package]]
@@ -3693,25 +3671,6 @@ checksum = "2c591d83f69777866b9126b24c6dd9a18351f177e49d625920d19f989fd31cf8"
 
 [[package]]
 name = "tungstenite"
-version = "0.20.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e3dac10fd62eaf6617d3a904ae222845979aec67c615d1c842b4002c7666fb9"
-dependencies = [
- "byteorder",
- "bytes",
- "data-encoding",
- "http 0.2.12",
- "httparse",
- "log",
- "rand",
- "sha1",
- "thiserror",
- "url",
- "utf-8",
-]
-
-[[package]]
-name = "tungstenite"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e2e2ce1e47ed2994fd43b04c8f618008d4cabdd5ee34027cf14f9d918edd9c8"
@@ -3719,7 +3678,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "data-encoding",
- "http 1.1.0",
+ "http",
  "httparse",
  "log",
  "rand",

--- a/netcanv-relay/Cargo.toml
+++ b/netcanv-relay/Cargo.toml
@@ -8,7 +8,8 @@ edition = "2021"
 netcanv-protocol = { path = "../netcanv-protocol" }
 
 tokio = { version = "1.32.0", features = ["full"] }
-tokio-tungstenite = "0.20.1"
+tokio-tungstenite = "0.23.1"
+rustls = { version = "0.23.10", default-features = false, features = ["ring"] }
 futures-util = { version = "0.3", features = ["sink", "std"] }
 serde = { version = "1.0.188", features = ["derive"] }
 bincode = "1.3.2"
@@ -17,4 +18,4 @@ nanorand = "0.7.0"
 anyhow = "1.0.75"
 structopt = "0.3.25"
 log = "0.4.20"
-simple_logger = "4.2.0"
+simple_logger = "5.0.0"


### PR DESCRIPTION
Updated dependencies:

- simple_logger 5.0.0
- tokio-tungstenite 0.23.1

Other changes:

- Add rustls for tokio-tungstenite (requirement by latest tokio-tungstenite)
