### PR TITLE
Send position and color to newly joined peer

### DIFF
--- a/src/app/paint/mod.rs
+++ b/src/app/paint/mod.rs
@@ -765,7 +765,7 @@ impl State {
                .peer
                .send_select_tool(self.toolbar.clone_tool_name(self.toolbar.current_tool()))?;
             self.toolbar.with_current_tool(|tool| {
-               tool.network_peer_join(ui, Net::new(&self.peer), peer_id)
+               tool.network_peer_join(ui, Net::new(&self.peer), peer_id, &self.global_controls)
             })?;
          }
          MessageKind::Left {

--- a/src/app/paint/tools/brush.rs
+++ b/src/app/paint/tools/brush.rs
@@ -494,6 +494,28 @@ impl Tool for BrushTool {
       Ok(())
    }
 
+   fn network_peer_join(
+      &mut self,
+      _renderer: &mut Backend,
+      net: Net,
+      peer_id: PeerId,
+      global_controls: &GlobalControls,
+   ) -> netcanv::Result<()> {
+      // Send to newly joined peer where and what color we are.
+      let Point { x, y } = self.mouse_position;
+      let Color { r, g, b, a } = Self::color(global_controls);
+      net.send(
+         self,
+         peer_id,
+         Packet::Cursor {
+            position: (x, y),
+            thickness: self.thickness() as u8,
+            color: (r, g, b, a),
+         },
+      )?;
+      Ok(())
+   }
+
    fn network_peer_activate(&mut self, _net: Net, peer_id: PeerId) -> netcanv::Result<()> {
       self.ensure_peer(peer_id);
       Ok(())

--- a/src/app/paint/tools/mod.rs
+++ b/src/app/paint/tools/mod.rs
@@ -151,6 +151,7 @@ pub trait Tool {
       _renderer: &mut Backend,
       _net: Net,
       _peer_id: PeerId,
+      _global_controls: &GlobalControls,
    ) -> netcanv::Result<()> {
       Ok(())
    }

--- a/src/app/paint/tools/selection.rs
+++ b/src/app/paint/tools/selection.rs
@@ -691,6 +691,7 @@ impl Tool for SelectionTool {
       renderer: &mut Backend,
       net: Net,
       peer_id: PeerId,
+      _global_controls: &GlobalControls,
    ) -> netcanv::Result<()> {
       if let Some(capture) = self.selection.download_rgba(renderer) {
          self.send_rect_packet(&net)?;


### PR DESCRIPTION
Before when peer joined already existing room, it will see other peers at (0, 0), until other peers move. Now, peers will send their state to newly joined peer.

Closes #190 