### PR TITLE
Encode PNG with synchronous method in 'ProjectFile::save_as_netcanv()'

### DIFF
--- a/src/image_coder.rs
+++ b/src/image_coder.rs
@@ -71,6 +71,24 @@ impl ImageCoder {
       Ok(CachedChunk { png, webp })
    }
 
+   /// Encodes an image to PNG data synchronously.
+   pub fn encode_png_data_sync(image: RgbaImage) -> netcanv::Result<Vec<u8>> {
+      let mut bytes: Vec<u8> = Vec::new();
+      match PngEncoder::new(Cursor::new(&mut bytes)).write_image(
+         &image,
+         image.width(),
+         image.height(),
+         ColorType::Rgba8,
+      ) {
+         Ok(()) => (),
+         Err(error) => {
+            tracing::error!("error while encoding: {}", error);
+            return Err(error.into());
+         }
+      }
+      Ok(bytes)
+   }
+
    /// Decodes a PNG file into the given sub-chunk.
    pub fn decode_png_data(data: &[u8]) -> netcanv::Result<RgbaImage> {
       let decoder = PngDecoder::new(Cursor::new(data))?;

--- a/src/project_file.rs
+++ b/src/project_file.rs
@@ -112,7 +112,7 @@ impl ProjectFile {
    }
 
    /// Saves the paint canvas as a `.netcanv` canvas.
-   async fn save_as_netcanv(
+   fn save_as_netcanv(
       &mut self,
       renderer: &mut Backend,
       path: &Path,
@@ -139,7 +139,7 @@ impl ProjectFile {
       for (chunk_position, chunk) in canvas.chunks_mut() {
          tracing::debug!("chunk {:?}", chunk_position);
          let image = chunk.download_image(renderer);
-         let image_data = ImageCoder::encode_png_data(image).await?;
+         let image_data = ImageCoder::encode_png_data_sync(image)?;
          let filename = format!("{},{}.png", chunk_position.0, chunk_position.1);
          let filepath = path.join(Path::new(&filename));
          tracing::debug!("saving to {:?}", filepath);
@@ -168,8 +168,7 @@ impl ProjectFile {
             Some("png") => self.save_as_png(renderer, &path, canvas),
             Some("netcanv") | Some("toml") => {
                // TODO: Saving should be asynchronous.
-               tokio::runtime::Handle::current()
-                  .block_on(async { self.save_as_netcanv(renderer, &path, canvas).await })
+               self.save_as_netcanv(renderer, &path, canvas)
             }
             _ => Err(Error::UnsupportedSaveFormat),
          }


### PR DESCRIPTION
This fixes crash caused by 'tokio::runtime::Handle::current().block_on()' when trying to save paint canvas in NetCanv format. The way it worked wasn't synchronous anyway, so it doesn't change anything by using synchronous method.

Closes #206