### PR TITLE
Remove a peer when relay tells us there is no such peer

### DIFF
--- a/netcanv-i18n/src/lib.rs
+++ b/netcanv-i18n/src/lib.rs
@@ -8,7 +8,7 @@ mod map;
 pub mod translate_enum;
 
 pub use error::*;
-pub use format::Formatted;
+pub use format::{FormatArg, Formatted};
 pub use language::*;
 pub use map::Map;
 

--- a/netcanv-protocol/src/relay.rs
+++ b/netcanv-protocol/src/relay.rs
@@ -7,6 +7,9 @@ use std::{
 
 use serde::{Deserialize, Serialize};
 
+#[cfg(feature = "i18n")]
+use netcanv_i18n::Formatted;
+
 /// The default relay port.
 pub const DEFAULT_PORT: u16 = 62137;
 
@@ -152,6 +155,13 @@ impl fmt::Debug for PeerId {
    }
 }
 
+#[cfg(feature = "i18n")]
+impl From<PeerId> for netcanv_i18n::FormatArg<'_> {
+   fn from(value: PeerId) -> Self {
+      Self::Unsigned(value.0)
+   }
+}
+
 /// An error.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
 #[cfg_attr(feature = "i18n", derive(netcanv_i18n::TranslateEnum))]
@@ -167,5 +177,5 @@ pub enum Error {
    /// The room with the given ID does not exist.
    RoomDoesNotExist,
    /// The peer with the given ID doesn't seem to be connected.
-   NoSuchPeer,
+   NoSuchPeer { address: PeerId },
 }

--- a/netcanv-relay/src/main.rs
+++ b/netcanv-relay/src/main.rs
@@ -302,7 +302,11 @@ async fn relay(
    } else if let Some(sink) = state.peers.peer_sinks.get(&target_id) {
       send_packet(sink, packet).await?;
    } else {
-      send_packet(write, Packet::Error(relay::Error::NoSuchPeer)).await?;
+      send_packet(
+         write,
+         Packet::Error(relay::Error::NoSuchPeer { address: target_id }),
+      )
+      .await?;
    }
 
    Ok(())


### PR DESCRIPTION
This fixes an error where if somehow relay's state and host's state are desynchronized and host thinks there is a peer that already left, leading to host sending a message to them and relay responding that the peer doesn't exists, which causes the host to leave the room.

See a comment in src/net/peer.rs to see why this is fine.

Closes #193 