### PR TITLE
Add more options to the CLI

### DIFF
--- a/src/app/boot.rs
+++ b/src/app/boot.rs
@@ -26,12 +26,10 @@ impl State {
       socket_system: Arc<SocketSystem>,
    ) -> Box<dyn AppState> {
       match cli.command {
-         Some(cli::Commands::HostRoom) => {
-            let peer = Some(Peer::host(
-               Arc::clone(&socket_system),
-               &config().lobby.nickname,
-               &config().lobby.relay,
-            ));
+         Some(cli::Commands::HostRoom { nickname, relay }) => {
+            let nickname = nickname.unwrap_or(config().lobby.nickname.clone());
+            let relay = relay.unwrap_or(config().lobby.relay.clone());
+            let peer = Some(Peer::host(Arc::clone(&socket_system), &nickname, &relay));
 
             Box::new(Self {
                assets,
@@ -39,11 +37,17 @@ impl State {
                peer,
             })
          }
-         Some(cli::Commands::JoinRoom { room_id }) => {
+         Some(cli::Commands::JoinRoom {
+            room_id,
+            nickname,
+            relay,
+         }) => {
+            let nickname = nickname.unwrap_or(config().lobby.nickname.clone());
+            let relay = relay.unwrap_or(config().lobby.relay.clone());
             let peer = Some(Peer::join(
                Arc::clone(&socket_system),
-               &config().lobby.nickname,
-               &config().lobby.relay,
+               &nickname,
+               &relay,
                room_id,
             ));
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -19,9 +19,22 @@ pub struct Cli {
 #[derive(Subcommand)]
 pub enum Commands {
    /// Host room when started
-   HostRoom,
+   HostRoom {
+      /// Nickname
+      #[arg(long)]
+      nickname: Option<String>,
+      /// Relay server address
+      #[arg(long)]
+      relay: Option<String>,
+   },
    /// Join room when started
    JoinRoom {
+      /// Nickname
+      #[arg(long)]
+      nickname: Option<String>,
+      /// Relay server address
+      #[arg(long)]
+      relay: Option<String>,
       /// Room ID used for joining the room
       #[arg(short, long, value_parser = clap::value_parser!(RoomId))]
       room_id: RoomId,


### PR DESCRIPTION
Now nickname and relay server address can be set from the command line.

Usage looks like this:

- `netcanv host-room --nickname <nickname> --relay <address>`
- `netcanv join-room --nickname <nickname> --relay <address> ...`