### PR TITLE
Copy a selection to clipboard with modifications

### DIFF
--- a/netcanv-renderer-opengl/src/rendering.rs
+++ b/netcanv-renderer-opengl/src/rendering.rs
@@ -898,6 +898,16 @@ impl RenderBackend for OpenGlBackend {
    ) {
       framebuffer.download_rgba(position, size, out_pixels);
    }
+   
+   fn download_framebuffer_scaled(
+      &mut self,
+      framebuffer: &Self::Framebuffer,
+      position: (u32, u32),
+      size: (u32, u32),
+      out_pixels: &mut [u8],
+   ) {
+      framebuffer.download_rgba_scaled(position, size, out_pixels);
+   }
 
    fn scale(&mut self, scale: Vector) {
       self.state.transform_mut().matrix *= Mat3A::from_scale(to_vec2(scale));

--- a/netcanv-renderer/src/lib.rs
+++ b/netcanv-renderer/src/lib.rs
@@ -164,6 +164,15 @@ pub trait RenderBackend: Renderer {
       out_pixels: &mut [u8],
    );
 
+   /// Downloads RGBA pixels from the framebuffer, scaled to fit into a buffer.
+   fn download_framebuffer_scaled(
+      &mut self,
+      framebuffer: &Self::Framebuffer,
+      position: (u32, u32),
+      size: (u32, u32),
+      out_pixels: &mut [u8],
+   );
+
    /// Scales the transform matrix by the given factor.
    fn scale(&mut self, scale: Vector);
 

--- a/src/app/paint/tools/selection.rs
+++ b/src/app/paint/tools/selection.rs
@@ -822,10 +822,23 @@ impl Selection {
    ///
    /// Returns `None` if there's no _captured_ selection.
    fn download_rgba(&self, renderer: &mut Backend) -> Option<RgbaImage> {
-      if let Some(capture) = self.capture.as_ref() {
-         let mut image = RgbaImage::new(capture.width(), capture.height());
-         renderer.download_framebuffer(capture, (0, 0), capture.size(), &mut image);
-         return Some(image);
+      if let Some(rect) = self.normalized_rect() {
+         let rect = rect.sort();
+         if let Some(capture) = self.capture.as_ref() {
+            tracing::trace!(
+               capture_size = ?capture.size(),
+               destination_size = ?(rect.width(), rect.height()),
+               "downloading a captured selection"
+            );
+            let mut image = RgbaImage::new(rect.width() as u32, rect.height() as u32);
+            renderer.download_framebuffer_scaled(
+               capture,
+               (0, 0),
+               (rect.width() as u32, rect.height() as u32),
+               &mut image,
+            );
+            return Some(image);
+         }
       }
       None
    }


### PR DESCRIPTION
This changes the behavior where copying a resized selection gives you it not resized. Now, it works as intended.

Closes #191 