### PR TITLE
Select existing color from the palette when picking the same color

### DIFF
--- a/src/ui/color_picker.rs
+++ b/src/ui/color_picker.rs
@@ -95,7 +95,14 @@ impl ColorPicker {
    /// Sets the currently selected color to the given (paws) color.
    pub fn set_color(&mut self, color: Color) {
       self.eraser = false;
-      self.palette[self.index] = Srgb::from_color(color).into();
+
+      // Check if the palette has the color already.
+      let color = Srgb::from_color(color).into();
+      if let Some(index) = self.palette.iter().position(|&c| c == color) {
+         self.index = index; // If it does, choose it.
+      } else {
+         self.palette[self.index] = color; // If it doesn't, replace the currently selected color.
+      }
    }
 
    /// Sets whether the eraser is enabled.


### PR DESCRIPTION
When we draw something using color from the palette, change the selected color, and pick the color we drew with the eyedropper, it overrides currently selected color in the palette with the picked color. This commit changes this behavior to, if the palette has the picked color already, not override the currently selected color, but change it to the color in the palette instead.

Closes #231 