### PR TITLE
Prevent resizing the window to 0x0

### DIFF
--- a/netcanv-renderer-opengl/src/lib.rs
+++ b/netcanv-renderer-opengl/src/lib.rs
@@ -129,12 +129,14 @@ impl OpenGlBackend {
 
    /// Resize the window.
    pub fn resize(&mut self, size: PhysicalSize<u32>) {
-      self.window_size = size;
-      self.surface.resize(
-         &self.context,
-         NonZeroU32::new(size.width).unwrap(),
-         NonZeroU32::new(size.height).unwrap(),
-      );
+      if size.width > 0 && size.height > 0 {
+         self.window_size = size;
+         self.surface.resize(
+            &self.context,
+            NonZeroU32::new(size.width).unwrap(),
+            NonZeroU32::new(size.height).unwrap(),
+         );
+      }
    }
 
    /// Swap buffers.

--- a/src/main.rs
+++ b/src/main.rs
@@ -135,6 +135,7 @@ async fn inner_main(language: &mut Option<Language>) -> errors::Result<()> {
       let event_loop = EventLoop::new();
       let window_builder = {
          let b = WindowBuilder::new()
+            .with_min_inner_size(PhysicalSize::<u32>::new(256, 150)) // not usable, but it's better than a crash.
             .with_inner_size(PhysicalSize::<u32>::new(1024, 600))
             .with_title("NetCanv")
             .with_resizable(true);


### PR DESCRIPTION
And set minimum inner size.
This prevents a crash when resizing the window on Windows.

Closes #240